### PR TITLE
fix a race condition in selecting a unique download path

### DIFF
--- a/extension/SDDownloadManager.mm
+++ b/extension/SDDownloadManager.mm
@@ -260,7 +260,9 @@ static id sharedManager = nil;
 	download.URLRequest = downloadRequest.urlRequest;
 	download.mimeType = downloadRequest.mimeType;
 	download.path = downloadRequest.savePath;
-	download.filename = [SDDownloadManager uniqueFilenameForFilename:downloadRequest.filename atPath:downloadRequest.savePath];
+	@synchronized([SDSafariDownload fileManager]) {
+		download.filename = [SDDownloadManager uniqueFilenameForFilename:downloadRequest.filename atPath:downloadRequest.savePath];
+	}
 	download.delegate = self;
 
 	[_downloadQueue addOperation:download];

--- a/extension/SDSafariDownload.h
+++ b/extension/SDSafariDownload.h
@@ -102,6 +102,7 @@ extern NSString * const kSDSafariDownloadTemporaryDirectory;
 
 @property (nonatomic, assign) NSObject<SDSafariDownloadDelegate> *delegate;
 
++ (NSFileManager*)fileManager;
 - (id)initWithDownload:(SDSafariDownload *)download;
 
 /*


### PR DESCRIPTION
Selecting a unique path was decoupled from the actual file creation,
so it was possible for two threads to select the same "unique" path.
I fixed this by creating a unique NSFileManager instance, which we
lock while performing directory lookups and file creation. Even though
this instance is not used when SandCastle is called to detect name
collisions, we can still rely on locking it as an abstract resource
to ensure correctness of the unique path selection code. Any time
we try to read the file list from disk, or modify it (via creation
or deletion) we lock the fileManager instance. I created an accessor
for it in SDSafariDownload so that SDDownloadManager could use it, but
ideally the unique path selection code should be localized to a single
location. If we didn't rely on setting download.filename within
SDDownloadManager, and instead always do this in SDSafariDownload
instances, there would be no need for the accessor.
